### PR TITLE
Replace deprecated seqlike encoder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,37 +1,37 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
-  hooks:
-  - id: trailing-whitespace
-  - id: end-of-file-fixer
-  - id: check-yaml
-- repo: https://github.com/psf/black
-  rev: 21.7b0
-  hooks:
-  - id: black
-    args: [--config, pyproject.toml]
-- repo: https://github.com/econchick/interrogate
-  rev: 1.4.0
-  hooks:
-  - id: interrogate
-    args: [-c, pyproject.toml]
-- repo: https://github.com/terrencepreilly/darglint
-  rev: v1.8.0
-  hooks:
-  - id: darglint
-    args: [-v 2]  # this config makes the error messages a bit less cryptic.
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
-  hooks:
-    - id: flake8
-      args: [--exclude, nbconvert_config.py]
-# - repo: https://github.com/kynan/nbstripout
-#   rev: 0.5.0
-#   hooks:
-#     - id: nbstripout
-- repo: https://github.com/pycqa/isort
-  rev: 5.8.0
-  hooks:
-    - id: isort
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black
+        args: [--config, pyproject.toml]
+  - repo: https://github.com/econchick/interrogate
+    rev: 1.5.0
+    hooks:
+      - id: interrogate
+        args: [-c, pyproject.toml]
+  - repo: https://github.com/terrencepreilly/darglint
+    rev: v1.8.1
+    hooks:
+      - id: darglint
+        args: [-v 2] # this config makes the error messages a bit less cryptic.
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        args: [--exclude, nbconvert_config.py]
+  # - repo: https://github.com/kynan/nbstripout
+  #   rev: 0.5.0
+  #   hooks:
+  #     - id: nbstripout
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort

--- a/therapeutic_enzyme_engineering_with_generative_neural_networks/gappy_sequences.py
+++ b/therapeutic_enzyme_engineering_with_generative_neural_networks/gappy_sequences.py
@@ -5,7 +5,7 @@ This is useful for MSA-based modeling, e.g., for neural networks or conservation
 import pandas as pd
 from seqlike.alignment_commands import mafft_alignment
 from seqlike.alphabets import gap_letter
-from seqlike.encoders import ENCODERS
+from seqlike.encoders import onehot_encoder_from_alphabet
 
 
 def gap_score(seqrec, counts, alphabet_letters, motif_depth, threshold=0.95):
@@ -38,7 +38,7 @@ def gap_score_sequences(aligned, threshold=0.95):
         greater than this percent
     :return: list of sorted gap scores
     """
-    counts = aligned.seq.as_counts(encoder=ENCODERS[aligned.seq._type]["onehot"]["full"])
+    counts = aligned.seq.as_counts(encoder=onehot_encoder_from_alphabet(aligned.seq.alphabet))
     gap_scores = [
         (gap_score(seqrec, counts, aligned.seq.alphabet, len(aligned), threshold=threshold), seqrec.id)
         for seqrec in aligned


### PR DESCRIPTION
Small change to make the `remove_gappy_seqs` notebook work again. Tested locally.